### PR TITLE
Improve error message

### DIFF
--- a/processor/src/main/kotlin/com/syouth/kmapper/processor/convertors/PojoClassTypeConverter.kt
+++ b/processor/src/main/kotlin/com/syouth/kmapper/processor/convertors/PojoClassTypeConverter.kt
@@ -59,7 +59,7 @@ internal class PojoClassTypeConverter(
             targetPath?.appendPathElement(additionalPath)
             val fromType = it.from?.type?.resolve()
             val converter = convertersManager.findConverterForTypes(fromType, it.to.type.resolve(), targetPath)
-            if (converter == null && !it.to.hasDefault) throw IllegalStateException("Do not know how to convert from ${fromObjectName.name}/${fromType?.declaration?.simpleName} to w${it.to.type.toTypeName()} with name ${it.to.name?.asString()} and path $targetPath") // No converter and no default value means fail
+            if (converter == null && !it.to.hasDefault) throw IllegalStateException("Do not know how to convert from ${fromObjectName.type}/${fromType} to w${it.to.type.toTypeName()} with name ${it.to.name?.asString()} and path $targetPath") // No converter and no default value means fail
             // Skip generation for inconvertible value with default
             if (converter == null && it.to.hasDefault) {
                 targetPath?.removeLastPathElement()


### PR DESCRIPTION
The addition I had made to the exception's error message wasn't really helpful, I'm afraid. This small PR makes it much more useful.

e.g.
from `Do not know how to convert from it/com.google.devtools.ksp.processing.impl.KSNameImpl@7a31a3ba to wjava.util.UUID with name id ...`
to   `Do not know how to convert from org.example.DomainPartType/UUID? to wjava.util.UUID with name id ... `